### PR TITLE
Add support for Cordova/PhoneGap with InAppBrowser

### DIFF
--- a/src/login.js
+++ b/src/login.js
@@ -13,13 +13,13 @@ Asteroid.prototype._initOauthLogin = function (service, credentialToken, loginUr
         var popupclosed = false;
 	
         if(isCordovaApp){
-		$(popup).on('loaderror', function(e) {
+		popup.addEventListener('loaderror', function(e) {
 		    setTimeout(function() {
                         popup.close();
                     }, 100);
                 });
 
-                $(popup).on('exit', function(e) { 
+                popup.addEventListener('exit', function(e) { 
                     popupclosed = true;
                 });
         }


### PR DESCRIPTION
This fix allow clients using PhoneGap and Cordova login with the same function. 
Tested: Works on desktop browser, Cordova, Phonegap with Meteor <= 0.8.0
To use the function, install Cordova plugin "org.apache.cordova.inappbrowser"
