### PR TITLE
Added chrome local storage (for browser extensions)

### DIFF
--- a/dist/asteroid.js
+++ b/dist/asteroid.js
@@ -991,7 +991,7 @@ Set.prototype.toArrayWithOptions = function(options) {
 
 }
 
-Set.prototype.filter = function (belongFn, options) {
+Set.prototype.filter = function (belongFn) {
 
 	// Creates the subset
 	var sub = new Set(true);


### PR DESCRIPTION
Vanilla localStorage doesn't share data across domains. To keep users logged across tabs / different websites, Chrome extensions need to access the login token anywhere by using the chrome.storage API (https://developer.chrome.com/apps/storage). It is asynchronous, hence the use of promises to get the localStorage data in this fork. Note: if used in a Chrome extension, you also have to ask your users the "storage" permission in the manifest.json file for it to work.
