### PR TITLE
Unable to install from package.json with nodejs 0.10.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   "dependencies": {
     "ddp.js": "^0.5.0",
     "q": "^1.0.1",
-    "faye-websocket": "^0.7.2",
+    "faye-websocket": "^0.7.2"
   }
 }


### PR DESCRIPTION
Minors modifications: file name for nodejs and dependencies update with faye-websocket
