### PR TITLE
Allow to createUsers with email and username

### DIFF
--- a/src/core/login.js
+++ b/src/core/login.js
@@ -83,12 +83,17 @@ Asteroid.prototype._tryResumeLogin = function () {
 Asteroid.prototype.createUser = function (usernameOrEmail, password, profile) {
 	var self = this;
 	var deferred = Q.defer();
-	var options = {
-		username: Asteroid.utils.isEmail(usernameOrEmail) ? undefined : usernameOrEmail,
-		email: Asteroid.utils.isEmail(usernameOrEmail) ? usernameOrEmail : undefined,
-		password: password,
-		profile: profile
-	};
+	var options;
+	if (typeof usernameOrEmail === "string") {
+		options = {
+			username: Asteroid.utils.isEmail(usernameOrEmail) ? undefined : usernameOrEmail,
+			email: Asteroid.utils.isEmail(usernameOrEmail) ? usernameOrEmail : undefined,
+			password: password,
+			profile: profile
+		};
+	} else if (typeof usernameOrEmail === "object") {
+		options = usernameOrEmail;
+	}
 	self.ddp.method("createUser", [options], function (err, res) {
 		if (err) {
 			self._emit("createUserError", err);


### PR DESCRIPTION
First of all thanks for this great Package! :+1: 

Anyway it is not possible to create a new User with `username` **and** `email`.

Since this is part of the Meteor [Accounts](http://docs.meteor.com/#accounts_ui_config) package I suggest the following fix.

This allows to pass an Object to `Asteroid.prototype.createUser`.

**Example:**

```
var ceres = new Asteroid('localhost:3000');
ceres.createUser({
    email: 'max@example.de'
    username: 'Max',
    password: 'secret123',
    profile: {}
}).then(...);
```

To be backwards compatible it is of course possible to use `Asteroid.prototype.createUser` in the old way.
