### PR TITLE
update README with facebook connect support info

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ If you want to login via oauth providers (facebook, google etc),
 also include the appropriate plugin:
 
     <script src="bower_components/asteroid/dist/plugins/facebook-login.js"></script>
+
+For facebook connect support in cordova via the [facebook connect plugin](https://github.com/Wizcorp/phonegap-facebook-plugin),
+see https://github.com/keyvanfatehi/asteroid-facebook-connect
     
 ###In a chrome extension or in cordova
 


### PR DESCRIPTION
Hi @pscanf 

I've created a meteor package and asteroid patch that enables native facebook connect to work seamlessly with the code you've already written in asteroid.

In this pull request I make a reference to it in the README under the appropriate section so that others can easily find it and install it via meteor and bower.

Thanks,
Keyvan