### PR TITLE
Update faye-websocket to at least 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/mondora/asteroid",
   "devDependencies": {
     "coveralls": "^2.11.2",
-    "faye-websocket": "^0.7.3",
+    "faye-websocket": "^0.10.0",
     "gulp": "^3.8.8",
     "gulp-concat": "^2.4.1",
     "istanbul": "^0.3.2",
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "ddp.js": "^0.5.0",
-    "faye-websocket": "^0.7.2",
+    "faye-websocket": "^0.10.0",
     "q": "^1.0.1"
   }
 }


### PR DESCRIPTION
Tested locally.

I hope they will also include SNI support with this PR soon:
https://github.com/faye/faye-websocket-node/pull/50