### PR TITLE
Need to set a username or email error

### DIFF
--- a/src/base-mixins/password-login.js
+++ b/src/base-mixins/password-login.js
@@ -11,13 +11,6 @@ import {onLogin} from "../common/login-method";
 */
 
 export function createUser ({username, email, password}) {
-    const options = {
-        password,
-        user: {
-            username,
-            email
-        }
-    };
     return this.call("createUser", options).then(onLogin.bind(this));
 }
 


### PR DESCRIPTION
Because accounts-password package expecting options object like this  `{username, email, password}`. Instead throws this error `Need to set a username or email`. [Link to source](https://github.com/meteor/meteor/blob/devel/packages/accounts-password/password_server.js#L981)