### PR TITLE
Resubscribe upon reconnection using the same id and same subscription object

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "sinon-chai": "^2.8.0"
   },
   "dependencies": {
-    "ddp.js": "^2.1.0",
+    "ddp.js": "^2.2.0",
     "lodash.assign": "^4.0.9",
     "wolfy87-eventemitter": "^5.0.0"
   }

--- a/src/base-mixins/subscriptions.js
+++ b/src/base-mixins/subscriptions.js
@@ -21,13 +21,10 @@ import fingerprintSub from "../common/fingerprint-sub";
 *   they are not exported so they don't clutter the Asteroid class prototype.
 */
 
-function restartSubscription ({id, name, params, stillInQueue}) {
+function restartSubscription ({ id, name, params, stillInQueue }) {
     // Only restart the subscription if it isn't still in ddp's queue.
     if (!stillInQueue) {
-        // The subscription must be deleted *before* re-subscribing, otherwise
-        // `subscribe` hits the cache and does nothing
-        this.subscriptions.cache.del(id);
-        this.subscribe(name, ...params);
+        this.resubcribe(id, name, params);
     }
 }
 
@@ -62,6 +59,10 @@ export function subscribe (name, ...params) {
 
 export function unsubscribe (id) {
     this.ddp.unsub(id);
+}
+
+export function resubcribe (id, name, params) {
+    this.ddp.sub(name, params, id);
 }
 
 /*

--- a/src/base-mixins/subscriptions.js
+++ b/src/base-mixins/subscriptions.js
@@ -25,6 +25,8 @@ function restartSubscription (sub) {
     // Only restart the subscription if it isn't still in ddp's queue.
     if (!sub.stillInQueue) {
         this.resubscribe(sub);
+    } else {
+        sub.stillInQueue = false;
     }
 }
 

--- a/src/base-mixins/subscriptions.js
+++ b/src/base-mixins/subscriptions.js
@@ -21,10 +21,10 @@ import fingerprintSub from "../common/fingerprint-sub";
 *   they are not exported so they don't clutter the Asteroid class prototype.
 */
 
-function restartSubscription ({ id, name, params, stillInQueue }) {
+function restartSubscription (sub) {
     // Only restart the subscription if it isn't still in ddp's queue.
-    if (!stillInQueue) {
-        this.resubscribe(id, name, params);
+    if (!sub.stillInQueue) {
+        this.resubscribe(sub);
     }
 }
 
@@ -61,8 +61,9 @@ export function unsubscribe (id) {
     this.ddp.unsub(id);
 }
 
-export function resubscribe (id, name, params) {
-    this.ddp.sub(name, params, id);
+export function resubscribe (sub) {
+    this.ddp.sub(sub.name, sub.params, sub.id);
+    sub.stillInQueue = (this.ddp.status !== "connected");
 }
 
 /*

--- a/src/base-mixins/subscriptions.js
+++ b/src/base-mixins/subscriptions.js
@@ -24,7 +24,7 @@ import fingerprintSub from "../common/fingerprint-sub";
 function restartSubscription ({ id, name, params, stillInQueue }) {
     // Only restart the subscription if it isn't still in ddp's queue.
     if (!stillInQueue) {
-        this.resubcribe(id, name, params);
+        this.resubscribe(id, name, params);
     }
 }
 
@@ -61,7 +61,7 @@ export function unsubscribe (id) {
     this.ddp.unsub(id);
 }
 
-export function resubcribe (id, name, params) {
+export function resubscribe (id, name, params) {
     this.ddp.sub(name, params, id);
 }
 

--- a/test/unit/base-mixins/subscriptions.js
+++ b/test/unit/base-mixins/subscriptions.js
@@ -3,6 +3,7 @@ import chaiAsPromised from "chai-as-promised";
 import sinon from "sinon";
 import sinonChai from "sinon-chai";
 import EventEmitter from "wolfy87-eventemitter";
+import assign from "lodash.assign"
 
 import * as subscriptionsMixin from "base-mixins/subscriptions";
 
@@ -95,7 +96,10 @@ describe("`subscriptions` mixin", () => {
 
         it("triggers a re-subscription to cached subscriptions which are not still in ddp's queue", () => {
             const instance = {
-                ddp: new EventEmitter(),
+                ddp: assign(new EventEmitter(), {
+                    sub: sinon.spy(),
+                    status: false // something that is not "connected"
+                }),
                 subscribe: sinon.spy(),
                 resubscribe: sinon.spy()
             };
@@ -114,13 +118,17 @@ describe("`subscriptions` mixin", () => {
                 params: ["2", "22", "222"],
                 stillInQueue: false
             });
+            instance.ddp.status = "connected";
             instance.ddp.emit("connected");
             expect(instance.resubscribe).to.have.callCount(2);
         });
 
         it("doesn't trigger a re-subscription to cached subscriptions which are still in ddp's queue", () => {
             const instance = {
-                ddp: new EventEmitter(),
+                ddp: assign(new EventEmitter(), {
+                    sub: sinon.spy(),
+                    status: false // something that is not "connected"
+                }),
                 subscribe: sinon.spy(),
                 resubscribe: sinon.spy()
             };
@@ -199,6 +207,51 @@ describe("`subscriptions` mixin", () => {
             expect(instance.ddp.sub).to.have.been.calledWith("name", ["param1", "param2"]);
         });
 
+    });
+
+    describe("`resubscribe` method", () => {
+        it("sets stillInQueue if ddp status is not 'connected'", () => {
+            var idCounter = 0;
+            const instance = {
+                ddp: assign(new EventEmitter(), {
+                    sub: sinon.spy(function(name, params, id) {
+                        return id || ++idCounter
+                    }),
+                    status: false // something that is not "connected"
+                }),
+                subscribe: subscriptionsMixin.subscribe,
+                resubscribe: subscriptionsMixin.resubscribe
+            };
+            subscriptionsMixin.init.call(instance);
+            
+            instance.subscribe("1", "1", "11", "111");
+
+            expect(instance.ddp.sub).to.have.callCount(1);
+
+            instance.ddp.status = "connected";
+            instance.ddp.emit("connected");
+
+            expect(instance.ddp.sub).to.have.callCount(1);
+
+            instance.subscribe("2", "2", "22", "222");
+
+            expect(instance.ddp.sub).to.have.callCount(2);
+
+            instance.subscriptions.cache.forEach(sub => {
+                expect(sub.stillInQueue).to.equal(false);
+            });
+
+            // reconnect happens!
+            instance.ddp.emit("connected");
+
+            // both subscriptions should be re-subscribed
+            expect(instance.ddp.sub).to.have.callCount(4);
+
+            // all subscriptions should be removed from the queue
+            instance.subscriptions.cache.forEach(sub => {
+                expect(sub.stillInQueue).to.equal(false);
+            });
+        });
     });
 
     describe("`unsubscribe` method", () => {

--- a/test/unit/base-mixins/subscriptions.js
+++ b/test/unit/base-mixins/subscriptions.js
@@ -140,7 +140,7 @@ describe("`subscriptions` mixin", () => {
                 stillInQueue: false
             });
 
-            instance.ddp.status = 'connected';
+            instance.ddp.status = "connected";
             instance.ddp.emit("connected");
 
             // re-subscribe should only be called for subscriptions
@@ -149,7 +149,7 @@ describe("`subscriptions` mixin", () => {
 
             // all subscriptions should be removed from the queue
             instance.subscriptions.cache.forEach(sub => {
-                expect(sub).to.have.property('stillInQueue', false);
+                expect(sub).to.have.property("stillInQueue", false);
             });
 
             // re a re-connection happens, resubscribe should be 

--- a/test/unit/base-mixins/subscriptions.js
+++ b/test/unit/base-mixins/subscriptions.js
@@ -3,7 +3,7 @@ import chaiAsPromised from "chai-as-promised";
 import sinon from "sinon";
 import sinonChai from "sinon-chai";
 import EventEmitter from "wolfy87-eventemitter";
-import assign from "lodash.assign"
+import assign from "lodash.assign";
 
 import * as subscriptionsMixin from "base-mixins/subscriptions";
 
@@ -214,8 +214,8 @@ describe("`subscriptions` mixin", () => {
             var idCounter = 0;
             const instance = {
                 ddp: assign(new EventEmitter(), {
-                    sub: sinon.spy(function(name, params, id) {
-                        return id || ++idCounter
+                    sub: sinon.spy(function (name, params, id) {
+                        return id || ++idCounter;
                     }),
                     status: false // something that is not "connected"
                 }),

--- a/test/unit/base-mixins/subscriptions.js
+++ b/test/unit/base-mixins/subscriptions.js
@@ -139,10 +139,23 @@ describe("`subscriptions` mixin", () => {
                 params: ["2", "22", "222"],
                 stillInQueue: false
             });
+
+            instance.ddp.status = 'connected';
             instance.ddp.emit("connected");
+
+            // re-subscribe should only be called for subscriptions
+            // those were not in queue already
             expect(instance.resubscribe).to.have.callCount(1);
+
+            // all subscriptions should be removed from the queue
+            instance.subscriptions.cache.forEach(sub => {
+                expect(sub).to.have.property('stillInQueue', false);
+            });
+
+            // re a re-connection happens, resubscribe should be 
+            // called twice more, reconnecting both subscribtions
             instance.ddp.emit("connected");
-            expect(instance.resubscribe).to.have.callCount(2);
+            expect(instance.resubscribe).to.have.callCount(3);
         });
 
     });

--- a/test/unit/base-mixins/subscriptions.js
+++ b/test/unit/base-mixins/subscriptions.js
@@ -96,7 +96,8 @@ describe("`subscriptions` mixin", () => {
         it("triggers a re-subscription to cached subscriptions which are not still in ddp's queue", () => {
             const instance = {
                 ddp: new EventEmitter(),
-                subscribe: sinon.spy()
+                subscribe: sinon.spy(),
+                resubscribe: sinon.spy()
             };
             subscriptionsMixin.init.call(instance);
             instance.subscriptions.cache.add({
@@ -114,14 +115,14 @@ describe("`subscriptions` mixin", () => {
                 stillInQueue: false
             });
             instance.ddp.emit("connected");
-            expect(instance.subscribe.firstCall).to.have.been.calledWith("n1", "1", "11", "111");
-            expect(instance.subscribe.secondCall).to.have.been.calledWith("n2", "2", "22", "222");
+            expect(instance.resubscribe).to.have.callCount(2);
         });
 
         it("doesn't trigger a re-subscription to cached subscriptions which are still in ddp's queue", () => {
             const instance = {
                 ddp: new EventEmitter(),
-                subscribe: sinon.spy()
+                subscribe: sinon.spy(),
+                resubscribe: sinon.spy()
             };
             subscriptionsMixin.init.call(instance);
             instance.subscriptions.cache.add({
@@ -139,7 +140,9 @@ describe("`subscriptions` mixin", () => {
                 stillInQueue: false
             });
             instance.ddp.emit("connected");
-            expect(instance.subscribe).to.have.callCount(1);
+            expect(instance.resubscribe).to.have.callCount(1);
+            instance.ddp.emit("connected");
+            expect(instance.resubscribe).to.have.callCount(2);
         });
 
     });


### PR DESCRIPTION
Basicly does what the title says.

I am not sure if this is as easily accaptable as the previous [PR](https://github.com/mondora/ddp.js/pull/29)

Please let me know what do you think.

In our use case ( a custom ddp server, asteroid + vue.js on frontend ); This helped updating a desynced clients' data, without adding reconnection handling logic or anything to the application code.