### PR TITLE
Added websocket import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.4 (Augustus 1, 2017)
+
+Added WebSocket import for node
+
 ## 2.0.3 (October 7, 2016)
 
 Fixed a bug on the subscription base mixin when restart the subscription.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asteroid",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Alternative Meteor client",
   "main": "lib/asteroid.js",
   "scripts": {
@@ -51,6 +51,7 @@
   "dependencies": {
     "ddp.js": "^2.2.0",
     "lodash.assign": "^4.2.0",
-    "wolfy87-eventemitter": "^5.1.0"
+    "wolfy87-eventemitter": "^5.1.0",
+    "ws": "^3.1.0"
   }
 }

--- a/src/base-mixins/ddp.js
+++ b/src/base-mixins/ddp.js
@@ -11,6 +11,8 @@
 
 import DDP from "ddp.js";
 
+import WebSocket from "ws";
+
 /*
 *   Public methods
 */


### PR DESCRIPTION
This pull request adds the import of the WebSocket package (https://www.npmjs.com/package/ws) to be able to run the asteroid package on node.

See #121 